### PR TITLE
Added symbol for mils.

### DIFF
--- a/lib/properties/length.dart
+++ b/lib/properties/length.dart
@@ -57,6 +57,7 @@ class Length extends DoubleProperty<LENGTH> {
               LENGTH.astronomicalUnits: 'au',
               LENGTH.lightYears: 'ly',
               LENGTH.parsec: 'pc',
+              LENGTH.mils: 'th',
             },
             conversionTree: ConversionNode(name: LENGTH.meters, leafNodes: [
               ConversionNode(


### PR DESCRIPTION
Added missing unit symbol for mils which is "th". "mil" is also used, mainly in the US.

https://simple.wikipedia.org/wiki/Thou_(unit)
