### PR TITLE
also bump version for ConverterNow (GPa)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.4
+- New pressure units: gigapascal (@Kheirlb)
+
 # 3.0.3
 - New mass unit: grains (@TheRealFakeAdmin)
 - New density units: lb/in³ and lb/ft³ (@Kheirlb)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: units_converter
 description: Simple and light units conversion package for all your needs.
-version: 3.0.3
+version: 3.0.4
 homepage: https://github.com/ferraridamiano/units_converter
 repository: https://github.com/ferraridamiano/units_converter
 issue_tracker: https://github.com/ferraridamiano/units_converter/issues


### PR DESCRIPTION
I tried updating ConverterNow but realized it depends on pub.dev. I guess this should have been done in https://github.com/ferraridamiano/units_converter/pull/57